### PR TITLE
fix(autocomplete): set the _default_search_fields for Profession

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -76,6 +76,8 @@ class ProfessionCategory(GenericModel, models.Model):
 
 
 class Profession(GenericModel, models.Model):
+    _default_search_fields = ["name"]
+
     class Meta:
         ordering = ("name",)
         verbose_name = _("Profession")


### PR DESCRIPTION
Profession has multiple CharFields, including one that stores the name
of the Profession entry in the old APIS instance, based on which the
Profession instance was created. When looking up something in
autocomplete, by default all CharFields of a model are searched. This
leads to false positives when searching. Therefore we use the new and
shiny `_default_search_fields` to force the Profession model only to
search the `name` field.

Closes: #293
