### PR TITLE
chore(deps): bump apis-core-rdf to v0.26.0 & default settings to v1.1.1

### DIFF
--- a/apis_ontology/templates/apis_core/apis_entities/abstractentity.html
+++ b/apis_ontology/templates/apis_core/apis_entities/abstractentity.html
@@ -1,5 +1,5 @@
 {% extends "apis_core/apis_entities/abstractentity.html" %}
-{% load apis_collections %}
+{% load collections %}
 
 {% block scriptHeader %}
 {{ block.super }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ packages = [{include = "apis_ontology"}]
 [tool.poetry.dependencies]
 python = "^3.11"
 psycopg2 = "^2.9"
-apis-core = {git = "https://github.com/acdh-oeaw/apis-core-rdf", rev = "v0.25.0"}
+apis-core = {git = "https://github.com/acdh-oeaw/apis-core-rdf", rev = "v0.26.0"}
 apis-highlighter-ng = "^0.4.0"
-apis-acdhch-default-settings = "1.0.0"
+apis-acdhch-default-settings = "1.1.1"
 django-acdhch-functions = "^0.1.3"
 django-auditlog = "^3.0.0"
 


### PR DESCRIPTION
The default settings updates the app order, which is needed to override
the base.html template.
