### PR TITLE
refactor(templates): use shipped map code

### DIFF
--- a/apis_ontology/templates/apis_core/apis_entities/abstractentity_form.html
+++ b/apis_ontology/templates/apis_core/apis_entities/abstractentity_form.html
@@ -1,39 +1,6 @@
 {% extends "apis_core/apis_entities/abstractentity_form.html" %}
 {% load apis_highlighter %}
 
-{% block scriptHeader %}
-{{ block.super }}
-<script type="text/javascript">
-function showmap(element) {
-  $('.popover').remove();
-  var rect = element.getBoundingClientRect();
-
-  mapdiv = document.createElement("div");
-  mapdiv.classList.add("popover");
-  mapdiv.setAttribute("id", "popovermap");
-  ptop = rect.top + window.scrollY - 250;
-  pleft = rect.left + window.scrollX - 550;
-  $(mapdiv).offset({top: ptop, left: pleft});
-  document.body.appendChild(mapdiv);
-
-  if (typeof map != "undefined") { map.off(); map.remove(); }
-  map = L.map('popovermap', { center: [element.dataset.latitude, element.dataset.longitude], zoom: 7 });
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors' }).addTo(map);
-  L.marker([element.dataset.latitude, element.dataset.longitude]).addTo(map);
-
-};
-function delmap(element) {
-  $('.popover').remove();
-}
-</script>
-<style>
-#popovermap {
-  width: 500px;
-  height: 500px;
-}
-</style>
-{% endblock %}
-
 {% block col-one %}
 
 {% if object.oebl_haupttext %}

--- a/apis_ontology/templates/apis_ontology/place_autocomplete_result.html
+++ b/apis_ontology/templates/apis_ontology/place_autocomplete_result.html
@@ -1,2 +1,0 @@
-{% load l10n %}
-{% if result.longitude and result.latitude %}<a {% localize off %}data-latitude="{{ result.latitude }}" data-longitude="{{ result.longitude }}"{% endlocalize %} title="Map" onmouseenter="showmap(this);" onmouseout="delmap(this);"><span class="material-symbols-outlined material-symbols-align">location_on</span></a>{% endif %} {{ result }} {% if result.kind %}<i>({{ result.kind }})</i>{% endif %} <a href="{{ result.uri }}">local result</a>

--- a/apis_ontology/templates/apis_ontology/place_external_autocomplete_result.html
+++ b/apis_ontology/templates/apis_ontology/place_external_autocomplete_result.html
@@ -1,1 +1,9 @@
-{% if result.document.coordinates %}<a data-latitude="{{ result.document.coordinates.0 }}" data-longitude="{{ result.document.coordinates.1 }}" title="Map" onmouseenter="showmap(this);" onmouseout="delmap(this);"><span class="material-symbols-outlined material-symbols-align">location_on</span></a>{% endif %} {% if result.highlight.label.snippet %}{{ result.highlight.label.snippet|safe }}{% else %}{{ result.document.label }}{% endif %} {% if result.document.id %}{{ result.document.id|urlize }}{% endif %}
+{% if result.document.coordinates %}
+  <a data-latitude="{{ result.document.coordinates.0|floatformat:"4u" }}"
+     data-longitude="{{ result.document.coordinates.1|floatformat:"4u" }}"
+     title="Map"
+     onmouseenter="showMap(this);"
+     onmouseout="delMap(this);"><span class="material-symbols-outlined material-symbols-align">location_on</span></a>
+{% endif %}
+{% if result.highlight.label.snippet %}{{ result.highlight.label.snippet|safe }}{% else %}{{ result.document.label }}{% endif %}
+{% if result.document.id %}{{ result.document.id|urlize }}{% endif %}


### PR DESCRIPTION
ApisCore now finally (!) ships its own map overlay code, which we can
reuse. Therefore we drop the custom code in the abstractentity_form.html
template and adapt the place_external_autocomplete_result.html template
accordingly.
We also drop the place_autocomplete_result.html template alltogether,
because Apis now also comes with an e53_place_autocomplete_result
template.
