### PR TITLE
birger/drop acdhch functions

### DIFF
--- a/apis_ontology/settings.py
+++ b/apis_ontology/settings.py
@@ -10,7 +10,6 @@ INSTALLED_APPS += [  # noqa: F405
 ]
 INSTALLED_APPS.remove("apis_ontology")
 INSTALLED_APPS.insert(0, "apis_ontology")
-INSTALLED_APPS += ["django_acdhch_functions"]
 INSTALLED_APPS += ["auditlog"]
 
 ROOT_URLCONF = "apis_ontology.urls"

--- a/apis_ontology/templates/base.html
+++ b/apis_ontology/templates/base.html
@@ -18,9 +18,3 @@
 </li>
 {% endblock main-menu %}
 
-{% block imprint %}
-  <div id="wrapper-footer-secondary"
-       class="footer-imprint-bar p-2 text-center">
-    <a href="{% url 'django_acdhch_functions:imprint' %}">Imprint | Impressum</a>
-  </div>
-{% endblock imprint %}

--- a/apis_ontology/urls.py
+++ b/apis_ontology/urls.py
@@ -21,8 +21,5 @@ urlpatterns = [
 urlpatterns += staticfiles_urlpatterns()
 # urlpatterns += [path("logger/", include("django_action_logger.urls")),]
 urlpatterns += [
-    path("", include("django_acdhch_functions.urls")),
-]
-urlpatterns += [
     path("auditlog", UserAuditLog.as_view()),
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ psycopg2 = "^2.9"
 apis-core = {git = "https://github.com/acdh-oeaw/apis-core-rdf", rev = "v0.27.0"}
 apis-highlighter-ng = "^0.4.0"
 apis-acdhch-default-settings = "1.4.0"
-django-acdhch-functions = "^0.1.3"
 django-auditlog = "^3.0.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
- chore(deps): drop the django_acdhch_functions dependency
- chore(deps): bump apis-acdhch-default-settings to v1.2.2
