### PR TITLE
chore: cleanup settings file

### DIFF
--- a/apis_ontology/settings.py
+++ b/apis_ontology/settings.py
@@ -17,39 +17,12 @@ ROOT_URLCONF = "apis_ontology.urls"
 CSRF_TRUSTED_ORIGINS = ["https://oebl-pnp.acdh-dev.oeaw.ac.at"]
 
 
-APIS_LIST_LINKS_TO_EDIT = True
-
-
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "verbose": {
-            "format": "%(asctime)s %(name)-6s %(levelname)-8s %(message)s",
-        },
-    },
-    "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
-            "formatter": "verbose",
-        },
-    },
-    "root": {
-        "handlers": ["console"],
-        "level": "DEBUG",
-    },
-}
-
-LOG_LIST_NOSTAFF_EXCLUDE_APP_LABELS = ["reversion", "admin", "sessions", "auth"]
-
 LANGUAGE_CODE = "de"
 
 MIDDLEWARE += [  # noqa: F405
     "auditlog.middleware.AuditlogMiddleware",
     "simple_history.middleware.HistoryRequestMiddleware",
 ]
-
-APIS_BASE_URI = "https://oebl-pfp.acdh-ch-dev.oeaw.ac.at"
 
 # this is a workaround to disable pagintation in the relations
 # listing on the entities pages


### PR DESCRIPTION
The APIS_LIST_LINKS_TO_EDIT setting is not used anymore in apis-core
The LOGGING setting is now part of the default settings app
The APIS_BASE_URI is set automatically by the default settings app
The LOG_LIST_NOSTAFF_EXCLUDE_APP_LABELS setting was for the
django-action-logger, which is not used anymore.
