### PR TITLE
fix: return empty result for URLs

### DIFF
--- a/apis_ontology/querysets.py
+++ b/apis_ontology/querysets.py
@@ -34,6 +34,8 @@ def InstitutionAutocompleteQueryset(model, query):
     # calculate a rank based on the difference in length
     # if the query is *not* contained in the result, we
     # use the trigram similarity score
+    if query.startswith("http"):
+        return model.objects.none()
     insitutions = (
         model.objects.annotate(
             icontains_rank=Case(


### PR DESCRIPTION
resolves #372
when a url is pasted to the autocomplete
just return an empty queryset to allow for
creation of the object.