### PR TITLE
feat(urls): drop custom url definitions

### DIFF
--- a/apis_ontology/urls.py
+++ b/apis_ontology/urls.py
@@ -1,18 +1,9 @@
-from django.contrib import admin
 from django.urls import include, path
-from django.views.generic import TemplateView
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
-from apis_core.apis_entities.api_views import GetEntityGeneric
+from apis_acdhch_default_settings.urls import urlpatterns
 
-
-urlpatterns = [
-    path("admin/", admin.site.urls),
-    path("apis/", include("apis_core.urls", namespace="apis")),
-    path("apis/collections/", include("apis_core.collections.urls")),
-    path("accounts/", include("django.contrib.auth.urls")),
-    path("entity/<int:pk>/", GetEntityGeneric.as_view(), name="GetEntityGenericRoot"),
-    path("", TemplateView.as_view(template_name="base.html")),
+urlpatterns += [
     path("highlighter/", include("apis_highlighter.urls", namespace="highlighter")),
 ]
 


### PR DESCRIPTION
Most of them are either defined in apis-core or in default settings
