### PR TITLE
fix(models): let the alternative_names field be null

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -237,7 +237,7 @@ class Person(
         "prompt_before_delete": False,
     }
 
-    alternative_names = JSONEditorField(schema=schema, options=options)
+    alternative_names = JSONEditorField(schema=schema, options=options, null=True)
 
     # texts
     # "ÖBL Haupttext"


### PR DESCRIPTION
The migrations for this field were apparently made with `null=True` but
this is not reflected in the models.py, so we add this argument now.
